### PR TITLE
SOFTWARE-5745: re-add el9 SHA1 fixes

### DIFF
--- a/add-trusted-sha1-certs.sh
+++ b/add-trusted-sha1-certs.sh
@@ -1,0 +1,50 @@
+# Helper script to facilitate generating two packages out of the certificate directory, one with
+# the certs as-is ($ORIG_SUFFIX) and one with all sha1 certs replaced by trusted certs ($TRUST_SUFFIX)
+
+# For each sha1-signed cert, create a duplicate trusted version to comply with EL9 default security policies
+# Give the original and trusted versions separate file suffixes, and also generate a separate set of
+# sha256sums for each set of certs
+
+# Directory to modify certs in
+CERT_DIR=$1
+# File suffix to apply to unmodified sha1 certs
+TRUST_SUFFIX=$2
+# File suffix to apply to modified sha1 certs
+ORIG_SUFFIX=$3
+
+# util function to find every sha1-signed cert
+find_sha1_certs() {
+    for f in $(find $1 -name "*.pem"); do 
+        if openssl x509 -noout -text < $f | grep "Signature Algorithm.*sha1" > /dev/null; then 
+            echo $f
+        fi
+    done
+}
+
+pushd $CERT_DIR
+
+# Rename the original sha256sum file that will be included with the package containing unmodified certs
+mv cacerts_sha256sum.txt cacerts_sha256sum.txt.$ORIG_SUFFIX
+
+# Then, find every sha1 certificate that will need to be changed to a trusted certificate
+TO_CHANGE=$(find_sha1_certs .)
+
+# change the certificate header/footer of SHA1-signed certificates to mark them as trusted
+echo $TO_CHANGE | xargs sed -r -i.orig -e 's/(BEGIN|END) CERTIFICATE/\1 TRUSTED CERTIFICATE/'
+# then append the originals to the certificate files so the files will contain both
+for orig in *.orig; do
+    new=${orig%.orig}
+    (echo; cat "$orig" ) >> "$new"
+    # Rename the original versions of each sha1 cert so they'll be included in the unmodified package
+    mv "$orig" "$new.$ORIG_SUFFIX"
+done
+
+# Create a new sha256sum file for the package containing updated certs
+sha256sum *.0 *.pem  > cacerts_sha256sum.txt.$TRUST_SUFFIX
+
+# Rename the modified versions of each sha1 cert so they'll be included in the trusted package
+for new in $TO_CHANGE; do
+    mv "$new" "$new.$TRUST_SUFFIX"
+done
+
+popd

--- a/add-trusted-sha1-certs.sh
+++ b/add-trusted-sha1-certs.sh
@@ -15,7 +15,7 @@ ORIG_SUFFIX=$3
 # util function to find every sha1-signed cert
 find_sha1_certs() {
     for f in $(find $1 -name "*.pem"); do 
-        if openssl x509 -noout -text < $f | grep "Signature Algorithm.*sha1" > /dev/null; then 
+        if openssl x509 -noout -text < $f | grep -q "Signature Algorithm.*sha1"; then 
             echo $f
         fi
     done

--- a/add-trusted-sha1-certs.sh
+++ b/add-trusted-sha1-certs.sh
@@ -7,7 +7,7 @@
 
 # Directory to modify certs in
 CERT_DIR=$1
-# File suffix to apply to unmodified sha1 certs
+# File suffix to apply to modified sha1 certs
 TRUST_SUFFIX=$2
 # File suffix to apply to modified sha1 certs
 ORIG_SUFFIX=$3

--- a/add-trusted-sha1-certs.sh
+++ b/add-trusted-sha1-certs.sh
@@ -9,7 +9,7 @@
 CERT_DIR=$1
 # File suffix to apply to modified sha1 certs
 TRUST_SUFFIX=$2
-# File suffix to apply to modified sha1 certs
+# File suffix to apply to unmodified sha1 certs
 ORIG_SUFFIX=$3
 
 # util function to find every sha1-signed cert

--- a/rpm/osg-ca-certs.spec
+++ b/rpm/osg-ca-certs.spec
@@ -4,13 +4,13 @@
 
 Name:           osg-ca-certs
 Version:        %{osg_version}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OSG Packaging of the IGTF CA Certs and OSG-specific CAs, in the OpenSSL 1.0.* format. 
 
 License:        Unknown
 URL:            http://repo.opensciencegrid.org/cadist/
 
-Source0:        https://github.com/opensciencegrid/osg-certificates/archive/v%{vtag}/osg-certificates-%{vtag}.tar.gz
+Source0:        https://github.com/opensciencegrid/osg-certificates/archive/v%{vtag}/osg-certificates-%{vtag}-%{release}.tar.gz
 Source1:        https://dist.eugridpma.info/distribution/igtf/current/igtf-policy-installation-bundle-%{igtf_version}.tar.gz
 Source2:        https://github.com/opensciencegrid/letsencrypt-certificates/archive/v0.3.2/letsencrypt-certificates.tar.gz
 # can obtain latest letsencrypt-certificates.tar.gz with a github.source line:
@@ -31,8 +31,18 @@ Conflicts:      osg-ca-scripts
 Obsoletes:      vdt-ca-certs
 Obsoletes:      osg-ca-certs-experimental
 Obsoletes:      osg-ca-certs-compat <= 1:1.37
+RemovePathPostfixes: .trusted-cert
 
 %description
+For details about the current certificate release, see https://repo.opensciencegrid.org/cadist/ and change log at https://repo.opensciencegrid.org/cadist/CHANGES.
+
+%package java
+Summary: Java-compatible SHA1 certs for %{name}
+BuildArch: noarch
+Conflicts: osg-ca-scripts
+RemovePathPostfixes: .java-cert
+
+%description java
 For details about the current certificate release, see https://repo.opensciencegrid.org/cadist/ and change log at https://repo.opensciencegrid.org/cadist/CHANGES.
 
 %prep
@@ -48,14 +58,17 @@ export CADIST=$PWD/certificates
 export PKG_NAME=%{name}
 
 ./build-certificates-dir.sh
+./add-trusted-sha1-certs.sh certificates trusted-cert java-cert
 
 %install
 mkdir -p $RPM_BUILD_ROOT/etc/grid-security/certificates
 mv certificates/* $RPM_BUILD_ROOT/etc/grid-security/certificates/
 
 %check
-cd $RPM_BUILD_ROOT/etc/grid-security/certificates
-sha256sum -c cacerts_sha256sum.txt
+# TODO how do we sha256sum the files that will have their names changed during install?
+# cd $RPM_BUILD_ROOT/etc/grid-security/certificates
+
+# sha256sum -c cacerts_sha256sum.txt
 
 %files
 %defattr(0644,root,root,-)
@@ -63,7 +76,16 @@ sha256sum -c cacerts_sha256sum.txt
 /etc/grid-security/certificates/*
 %doc
 
+%files java
+%defattr(0644,root,root,-)
+%dir %attr(0755,root,root) /etc/grid-security/certificates
+/etc/grid-security/certificates/*
+%doc
+
 %changelog
+* Thu Nov 9 2023 Matt Westphall <westphall@wisc.edu> - 1.115-2
+- Re-add el9 cert changes, create secondary package with original certs (SOFTWARE-5745)
+
 * Tue Oct 31 2023 Mátyás Selmeci <matyas@cs.wisc.edu> - 1.115-1
 - Update to IGTF 1.124 (SOFTWARE-5738)
 


### PR DESCRIPTION
- Re-add the bash script that updates the SHA1 signed certs to trusted certs
- Add a -java sub-package that contains the unmodified SHA1 certs via some name shuffling with [RemovePathPostfixes](https://rpm-software-management.github.io/rpm/manual/spec.html#removepathpostfixes)