### PR TITLE
Update to IGTF CA certs 1.125; remove EL9 SHA1 workaround for osg-ca-certs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,8 +9,13 @@ the VDT, then please refer to this link:
 OSG CA Package in new format (md5, sha1 hashes) to support openssl 1.x
 
 
+===== Version 1.116 (IGTF 1.125) ===========
+Built 29 NOV 2023
+
+* updated root certificate ArmeSFo CA with extended validity (AM)
+
 ===== Version 1.115 (IGTF 1.124) ===========
-Built 31 NOV 2023
+Built 31 OCT 2023
 
 * updated contact meta-data for ArmeSFo authority (AM)
 * removed discontinued AEGIS authority (RS)

--- a/rpm/igtf-ca-certs.spec
+++ b/rpm/igtf-ca-certs.spec
@@ -1,6 +1,6 @@
-%define igtf_version 1.124
-%define osg_version  1.115
-%define release_num  2
+%define igtf_version 1.125
+%define osg_version  1.116
+%define release_num  1
 %define vtag         %{osg_version}.igtf.%{igtf_version}-%{release_num}
 
 Name:           igtf-ca-certs
@@ -61,6 +61,9 @@ sha256sum -c cacerts_sha256sum.txt
 %doc
 
 %changelog
+* Wed Nov 29 2023 Mátyás Selmeci <matyas@cs.wisc.edu> - 1.125-1
+- Update to IGTF 1.125 (SOFTWARE-5764)
+
 * Tue Oct 31 2023 Mátyás Selmeci <matyas@cs.wisc.edu> - 1.124-1
 - Update to IGTF 1.124 (SOFTWARE-5738)
 

--- a/rpm/osg-ca-certs.spec
+++ b/rpm/osg-ca-certs.spec
@@ -1,6 +1,6 @@
-%define igtf_version 1.124
-%define osg_version  1.115
-%define release_num  2
+%define igtf_version 1.125
+%define osg_version  1.116
+%define release_num  1
 %define vtag         %{osg_version}.igtf.%{igtf_version}-%{release_num}
 
 Name:           osg-ca-certs
@@ -84,6 +84,9 @@ mv certificates/* $RPM_BUILD_ROOT/etc/grid-security/certificates/
 %doc
 
 %changelog
+* Wed Nov 29 2023 Mátyás Selmeci <matyas@cs.wisc.edu> - 1.116-1
+- Update to IGTF 1.125; remove el9 cert changes (SOFTWARE-5764)
+
 * Thu Nov 9 2023 Matt Westphall <westphall@wisc.edu> - 1.115-2
 - Re-add el9 cert changes, create secondary package with original certs (SOFTWARE-5745)
 

--- a/rpm/osg-ca-certs.spec
+++ b/rpm/osg-ca-certs.spec
@@ -2,6 +2,7 @@
 %define osg_version  1.116
 %define release_num  1
 %define vtag         %{osg_version}.igtf.%{igtf_version}-%{release_num}
+%define enable_trusted_sha1_certs 0
 
 Name:           osg-ca-certs
 Version:        %{osg_version}
@@ -59,7 +60,14 @@ export CADIST=$PWD/certificates
 export PKG_NAME=%{name}
 
 ./build-certificates-dir.sh
+
+%if 0%{?enable_trusted_sha1_certs}
 ./add-trusted-sha1-certs.sh certificates trusted-cert java-cert
+%else
+# We still want to make the osg-ca-certs and osg-ca-certs-java RPMs
+find certificates -name "*.pem" -exec cp '{}' '{}.java-cert' ';'
+find certificates -name "*.pem" -exec mv '{}' '{}.trusted-cert' ';'
+%endif
 
 %install
 mkdir -p $RPM_BUILD_ROOT/etc/grid-security/certificates


### PR DESCRIPTION
SOFTWARE-5764. This removes the SHA1 workaround from osg-ca-certs but still keeps the osg-ca-certs-java RPM to make upgrades easier.