### PR TITLE
Do not build osg-ca-certs-java on EL7

### DIFF
--- a/rpm/osg-ca-certs.spec
+++ b/rpm/osg-ca-certs.spec
@@ -33,11 +33,14 @@ Conflicts:      osg-ca-scripts
 Obsoletes:      vdt-ca-certs
 Obsoletes:      osg-ca-certs-experimental
 Obsoletes:      osg-ca-certs-compat <= 1:1.37
+%if 0%{?rhel} >= 8
 RemovePathPostfixes: .trusted-cert
+%endif
 
 %description
 For details about the current certificate release, see https://repo.opensciencegrid.org/cadist/ and change log at https://repo.opensciencegrid.org/cadist/CHANGES.
 
+%if 0%{?rhel} >= 8
 %package java
 Summary: Java-compatible SHA1 certs for %{name}
 BuildArch: noarch
@@ -46,6 +49,7 @@ RemovePathPostfixes: .java-cert
 
 %description java
 For details about the current certificate release, see https://repo.opensciencegrid.org/cadist/ and change log at https://repo.opensciencegrid.org/cadist/CHANGES.
+%endif
 
 %prep
 %setup    -n osg-certificates-%{vtag}
@@ -61,12 +65,14 @@ export PKG_NAME=%{name}
 
 ./build-certificates-dir.sh
 
+%if 0%{?rhel} >= 8
 %if 0%{?enable_trusted_sha1_certs}
 ./add-trusted-sha1-certs.sh certificates trusted-cert java-cert
 %else
 # We still want to make the osg-ca-certs and osg-ca-certs-java RPMs
 find certificates -name "*.pem" -exec cp '{}' '{}.java-cert' ';'
 find certificates -name "*.pem" -exec mv '{}' '{}.trusted-cert' ';'
+%endif
 %endif
 
 %install
@@ -85,13 +91,18 @@ mv certificates/* $RPM_BUILD_ROOT/etc/grid-security/certificates/
 /etc/grid-security/certificates/*
 %doc
 
+%if 0%{?rhel} >= 8
 %files java
 %defattr(0644,root,root,-)
 %dir %attr(0755,root,root) /etc/grid-security/certificates
 /etc/grid-security/certificates/*
 %doc
+%endif
 
 %changelog
+* Wed Nov 29 2023 Mátyás Selmeci <matyas@cs.wisc.edu> - 1.116-2
+- Do not attempt to build osg-ca-certs-java on el7 (SOFTWARE-5764)
+
 * Wed Nov 29 2023 Mátyás Selmeci <matyas@cs.wisc.edu> - 1.116-1
 - Update to IGTF 1.125; remove el9 cert changes (SOFTWARE-5764)
 

--- a/rpm/osg-ca-certs.spec
+++ b/rpm/osg-ca-certs.spec
@@ -1,6 +1,6 @@
 %define igtf_version 1.125
 %define osg_version  1.116
-%define release_num  1
+%define release_num  2
 %define vtag         %{osg_version}.igtf.%{igtf_version}-%{release_num}
 %define enable_trusted_sha1_certs 0
 


### PR DESCRIPTION
its version of rpmbuild does not understand RemovePathPostfixes